### PR TITLE
Add skeleton for adding terminal commands

### DIFF
--- a/clockify_tui/__init__.py
+++ b/clockify_tui/__init__.py
@@ -1,6 +1,9 @@
 """The main module for Clockify TUI."""
 
+import sys
 from importlib.metadata import version
+
+import click
 
 from .ui import UI
 
@@ -9,5 +12,20 @@ __version__ = version(__name__)
 
 def main() -> None:
     """The main entry point to the program."""
+    # If the user doesn't supply a command, launch the TUI
+    if len(sys.argv) < 2:
+        tui()
+    else:
+        cli()
+
+
+@click.group()
+def cli() -> None:
+    """The top-level group containing all the commands for Clockify TUI."""
+
+
+@cli.command()
+def tui() -> None:
+    """Launch the TUI."""
     ui = UI()
     ui.run()

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,20 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -563,4 +577,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "5e451467ef5859e720c533ac97691eb2688a42d4b92c54adb39a968c399eec20"
+content-hash = "7154ceb8dc8be7d043db0c02c5abb8d1f624cd60923cd6f623ff1da9865d4eb9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ clockify-tui = "clockify_tui:main"
 [tool.poetry.dependencies]
 python = "^3.12"
 blessed = "^1.20.0"
+click = "^8.1.7"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
# Description

Currently we just launch the TUI when the user invokes the program, but going forward we will also want to be able to do other things for which we will need other commands. I've used the `click` package to allow for adding other commands and I've added one to get us started (`tui`).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
